### PR TITLE
AEM-API.py Enhancement Suggestions 1, 2, and 3 from Timon (Cellforce Group GmbH)

### DIFF
--- a/AEM_API.py
+++ b/AEM_API.py
@@ -29,12 +29,12 @@ API_HOME_PATH = os.path.dirname(os.path.realpath(__file__))
 DLM_EXECUTABLE = "DLM_Executable.exe"
 
 ## SOLVENT AND SALT DIRECTORY PATHS
-SOLVENT_DB = "data\\solventDB.csv"
-SALT_DB = "data\\saltDB.csv"
-AEM_SOLVENTS = "data\\AEM_solvents.csv"
-AEM_SALTS = "data\\AEM_salts.csv"
-AEM_ACCC_SOLVENTS = "data\\AEM_ACCC_solvents.csv"
-AEM_ACCC_SALTS = "data\\AEM_ACCC_salts.csv"
+SOLVENT_DB = os.path.join(API_HOME_PATH, "data", "solventDB.csv")
+SALT_DB = os.path.join(API_HOME_PATH, "data", "saltDB.csv")
+AEM_SOLVENTS = os.path.join(API_HOME_PATH, "data", "AEM_solvents.csv")
+AEM_SALTS = os.path.join(API_HOME_PATH, "data", "AEM_salts.csv")
+AEM_ACCC_SOLVENTS = os.path.join(API_HOME_PATH, "data", "AEM_ACCC_solvents.csv")
+AEM_ACCC_SALTS = os.path.join(API_HOME_PATH, "data", "AEM_ACCC_salts.csv")
     
 ## ElectrolyteComposition CLASS
 class ElectrolyteComposition:
@@ -334,6 +334,7 @@ class AEM_API:
                  run_name=None,
                  AEMHomePath=None,
                  AEMProgramName=None):
+        self.AEMHomePath = AEMHomePath
         DLMout = self.runDLMExecutable()
         if DLMout == '1':
             self.read_AEM_data(salt_csv, solvent_csv)
@@ -380,7 +381,6 @@ class AEM_API:
         else:
             self.run_output_dir = os.path.join(self.output_dir, f"AEMAPIRun_{self.run_name}_{self.run_date}_{self.run_time}")
         os.makedirs(self.run_output_dir, exist_ok=True)
-        self.AEMHomePath = AEMHomePath
     print(f"### AEM-API v1.0:: Starting Program!")
     
     # Method to read AEM data from CSV files
@@ -418,12 +418,9 @@ class AEM_API:
     # Method to run the AEM model
     def runDLMExecutable(self):
         print(f"### AEM-API v1.0:: Checking ACCC Access from DLM ...")
-        # Path to the executable
-        homedir = os.path.expanduser("~")
-        AEM_HOME = rf'{homedir}\Documents\AEM\CLI'   # Path to AEM/CLI/ (Update path if different!)
-        fp = os.path.join(AEM_HOME, DLM_EXECUTABLE)
+        fp = os.path.join(self.AEMHomePath, DLM_EXECUTABLE)
         # Run the executable with the 'check' argument
-        p = sp.Popen([fp, 'check'], shell=True, stdout=sp.PIPE, stderr=sp.STDOUT, cwd=AEM_HOME)
+        p = sp.Popen([fp, 'check'], shell=True, stdout=sp.PIPE, stderr=sp.STDOUT, cwd=self.AEMHomePath)
         # Capture the output
         stdout, _ = p.communicate()  # Capture output
         stdout = stdout.decode('utf-8').strip()  # Decode and strip any extra whitespace/newlines
@@ -735,7 +732,7 @@ class AEM_API:
             src = os.path.join(self.AEMHomePath, report_file)
             dstfolder = os.path.join(self.run_output_dir,"Reports")
             os.makedirs(dstfolder, exist_ok=True)
-            dst = os.path.join(dstfolder, report_file)
+            dst = os.path.join(dstfolder, f"{report_file}.txt")
             if os.path.exists(src):
                 shutil.copy(src, dst)
             else:


### PR DESCRIPTION
1. As part of the AEM-API repository, there is this executable “DLM_Executable.exe” which is called by a dedicated method (runDLMExecutable) when the AEM_API class is initialized. Within this method, you (re)define a global AEM_HOME variable and there seems to be no way of modifying this externally. We rather suggest that you use the global API_HOME_PATH from above, as this is more appropriate in this context,  and use the class attribute AEMHomePath as the cwd argument to the subprocess call which becomes possible when you change the order of the commands in the init method.
**Changes:**
`fp = os.path.join(AEM_HOME, DLM_EXECUTABLE)` --> `fp = os.path.join(self.AEMHomePath, DLM_EXECUTABLE)`
`p = sp.Popen([fp, 'check'], shell=True, stdout=sp.PIPE, stderr=sp.STDOUT, cwd=self.AEMHomePath)`

2. At the beginning of the file, you define the solvent and salt directory paths relative to the working directory from which the Python script with main is called. It is better to make these paths absolute by using the global API_HOME_PATH variable again so the user doesn’t have to change the working directory accordingly.
**Changes:**
`SOLVENT_DB = "data\\solventDB.csv"` --> `SOLVENT_DB = os.path.join(API_HOME_PATH, "data", "solventDB.csv")`, and so on for other similar lines.

3. When copying the report files within the “copy_report_files” method, you are missing the ‘.txt’ file extension to indicate the file type and make it easier for users to open the reports. Simply add an extra ‘.txt’ to the “dst” variable and the file extensions will be the same as when AEM is run from the GUI.
**Changes:**
`dst = os.path.join(dstfolder, report_file)` --> `dst = os.path.join(dstfolder, f"{report_file}.txt")`