### PR TITLE
AEM-API.py Enhancement Suggestion 1 from Timon (Cellforce Group GmbH) update for making DLMExecutable run from the AEM-API working directory.

### DIFF
--- a/AEM_API.py
+++ b/AEM_API.py
@@ -418,7 +418,7 @@ class AEM_API:
     # Method to run the AEM model
     def runDLMExecutable(self):
         print(f"### AEM-API v1.0:: Checking ACCC Access from DLM ...")
-        fp = os.path.join(self.AEMHomePath, DLM_EXECUTABLE)
+        fp = os.path.join(API_HOME_PATH, DLM_EXECUTABLE)
         # Run the executable with the 'check' argument
         p = sp.Popen([fp, 'check'], shell=True, stdout=sp.PIPE, stderr=sp.STDOUT, cwd=self.AEMHomePath)
         # Capture the output

--- a/configs.ini
+++ b/configs.ini
@@ -1,0 +1,8 @@
+
+[License]
+  LIC_HOST             = aem.ridgetopgroup.com
+  LIC_PORT             = 443
+  LIC_HTTP_USERAGENT   = DlmApplication/0.1
+  LIC_API_ADDR         = /users/api/getlicense
+  LIC_FEATURE          = AEM_ACCC
+  LIC_WAIT_TIMEOUT_SEC = 20


### PR DESCRIPTION
1. As part of the AEM-API repository, there is this executable “DLM_Executable.exe” which is called by a dedicated method (runDLMExecutable) when the AEM_API class is initialized. Within this method, you (re)define a global AEM_HOME variable and there seems to be no way of modifying this externally. We rather suggest that you use the global API_HOME_PATH from above, as this is more appropriate in this context,  and use the class attribute AEMHomePath as the cwd argument to the subprocess call which becomes possible when you change the order of the commands in the init method.
**Changes:**
`fp = os.path.join(self.AEMHomePath, DLM_EXECUTABLE)` --> `fp = os.path.join(API_HOME_PATH, DLM_EXECUTABLE)` 